### PR TITLE
Fix Colormap update

### DIFF
--- a/js/lib/src/BlockUtils/PlugInBlock.js
+++ b/js/lib/src/BlockUtils/PlugInBlock.js
@@ -838,6 +838,14 @@ class PlugInBlock extends Block {
       child.updateGeometry(true);
     });
   }
+
+  updateMaterial () {
+    this.buildMaterials();
+
+    this.childrenBlocks.forEach((child) => {
+      child.updateMaterial();
+    });
+  }
 }
 
 /**


### PR DESCRIPTION
This is a fix for #19. But only for the colormap update. We should get rid of all the `replace*Node` calls, not only for color.